### PR TITLE
fix: only run the workflow on the upstream

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   call-upgrade-python-requirements-workflow:
+    # Do not run on forks
+    if: github.repository == 'openedx/DoneXBlock'
     uses: openedx/.github/.github/workflows/upgrade-python-requirements.yml@master
     with:
       branch: ${{ github.event.inputs.branch || '$default-branch' }}


### PR DESCRIPTION
To facilitate the fork workflow, it is helpful to restrict some GitHub actions to run only on the upstream repository.