### PR TITLE
feat: scan for action updates

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,13 @@
+# Set update schedule for GitHub Actions
+# Only checking for action updates as we are using the custom
+# requirements bot for application dependency upgrades
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"
+


### PR DESCRIPTION
This introduces Dependabot, but only for the purpose of tracking upgrades to GitHub actions.  Application dependencies are handled via the requirements bot, which uses make upgrade.