### PR TITLE
build: add URL metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ setup(
     name='done-xblock',
     version=VERSION,
     description='done XBlock',   # TODO: write a better description.
+    url='https://github.com/openedx/DoneXBlock',
     classifiers=[
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
We count on the URL metadata to connect PyPI packages to GitHub repos.