### PR TITLE
build: Manually pull some RTD Context.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,3 +107,14 @@ intersphinx_mapping = {
 
 # -- Options for autosummary extension ---------------------------------------
 autosummary_imported_members = True
+
+# -- Read the Docs Specific Configuration
+# Define the canonical URL if you are using a custom domain on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
+


### PR DESCRIPTION
See https://about.readthedocs.com/blog/2024/07/addons-by-default/ for details but
essentially RTD is changing how it's building docs and this will let us handle the
change gracefully.
